### PR TITLE
Avoid error messages / warnings and adjust to 1.0.2 Swisscom Template

### DIFF
--- a/themes/abacus-bootstrap/core/frontpage_federation.tpl.php
+++ b/themes/abacus-bootstrap/core/frontpage_federation.tpl.php
@@ -67,7 +67,7 @@ foreach($this->data['metaentries']['remote'] AS $setkey => $set) {
 	foreach($set AS $entry) {
 		echo '<li>';
 		echo ('<a href="' . 
-			htmlspecialchars(SimpleSAML_Module::getModuleURL('core/show_metadata.php', array('entityid' => $entry['entityid'], 'set' => $setkey ))) .
+			htmlspecialchars(SimpleSAML\Module::getModuleURL('core/show_metadata.php', array('entityid' => $entry['entityid'], 'set' => $setkey ))) .
 			'">');
 		if (array_key_exists('name', $entry)) {
 			echo htmlspecialchars($this->getTranslation(SimpleSAML_Utilities::arrayize($entry['name'], 'en')));
@@ -110,7 +110,7 @@ foreach($this->data['metaentries']['remote'] AS $setkey => $set) {
 
             <?php if ($this->data['isadmin']) { ?>
             <div class="span6">
-                <form action="<?php echo SimpleSAML_Module::getModuleURL('core/show_metadata.php'); ?>" method="get" >
+                <form action="<?php echo SimpleSAML\Module::getModuleURL('core/show_metadata.php'); ?>" method="get" >
                     <fieldset class="fancyfieldset"><legend>Lookup metadata</legend>
                         <p style="margin: 1em 2em ">Look up metadata for entity:
                             <select name="set">

--- a/themes/abacus-bootstrap/default/includes/footer.php
+++ b/themes/abacus-bootstrap/default/includes/footer.php
@@ -11,6 +11,6 @@ if(!empty($this->data['htmlinject']['htmlContentPost'])) {
 </footer>
 </div><!-- /container-fluid -->
 <script type="text/javascript" src="/<?php echo $this->data['baseurlpath']; ?>resources/script.js"></script>
-<script type="text/javascript" src="<?php echo SimpleSAML_Module::getModuleUrl('abacustheme/js/bootstrap.min.js') ?>"></script>
+<script type="text/javascript" src="<?php echo SimpleSAML\Module::getModuleUrl('abacustheme/js/bootstrap.min.js') ?>"></script>
 </body>
 </html>

--- a/themes/abacus-bootstrap/default/includes/header.php
+++ b/themes/abacus-bootstrap/default/includes/header.php
@@ -24,7 +24,7 @@ if (array_key_exists('pageid', $this->data)) {
 		'page' => $this->data['pageid']
 	);
 		
-	SimpleSAML_Module::callHooks('htmlinject', $hookinfo);	
+	SimpleSAML\Module::callHooks('htmlinject', $hookinfo);	
 }
 // - o - o - o - o - o - o - o - o - o - o - o - o -
 
@@ -51,11 +51,11 @@ if(array_key_exists('header', $this->data)) {
 }
 ?></title>
 
-    <link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML_Module::getModuleUrl('abacustheme/css/bootstrap.min.css') ?>" />
-	<link rel="icon" type="image/icon" href="<?php echo SimpleSAML_Module::getModuleUrl('abacustheme/pics/favicon.ico') ?>" />
+    <link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleUrl('abacustheme/css/bootstrap.min.css') ?>" />
+	<link rel="icon" type="image/icon" href="<?php echo SimpleSAML\Module::getModuleUrl('abacustheme/pics/favicon.ico') ?>" />
 
 
-<script type="text/javascript" src="<?php echo SimpleSAML_Module::getModuleUrl('abacustheme/js/bootstrap.min.js') ?>"></script>
+<script type="text/javascript" src="<?php echo SimpleSAML\Module::getModuleUrl('abacustheme/js/bootstrap.min.js') ?>"></script>
 <?php
 $jquery = array();
 $jquery['version'] = '1.11.1';
@@ -224,7 +224,7 @@ if($onLoad !== '') {
 <div class="container-fluid col-sm-12 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3" style="max-width:800px;">
 	<div class="row-fluid">
 		    <header class="page-header" style="margin-top:20px">
-			<img src="<?php echo SimpleSAML_Module::getModuleUrl('abacustheme/pics/abacus_logo.gif') ?>" style="padding-bottom:10px"/>
+			<img src="<?php echo SimpleSAML\Module::getModuleUrl('abacustheme/pics/abacus_logo.gif') ?>" style="padding-bottom:10px"/>
 		    </header>
 	</div>
 	<div class="row-fluid">

--- a/themes/abacus-bootstrap/mobileid/mobileidtemplate.php
+++ b/themes/abacus-bootstrap/mobileid/mobileidtemplate.php
@@ -2,26 +2,37 @@
 /**
  * This is the associated template page for the Mobile ID login form
  *
- * @version     1.0.0
+ * @version     1.0.2 (ABACUS)
  * @package     simpleSAMLphp-mobileid
  * @copyright   Copyright (C) 2012. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.md
- * @author      Swisscom (Schweiz AG)
+ * @author      Swisscom (Schweiz) AG
  */
 
-$this->data['head'] .= '<script type="text/javascript" src="' . SimpleSAML_Module::getModuleUrl('mobileid/resources/js/mobileid.js') . '"></script>';
+$this->data['head']  = '<script type="text/javascript" src="' . SimpleSAML\Module::getModuleUrl('mobileid/resources/js/jquery/jquery-1.8.3.min.js') . '"></script>';
+$this->data['head'] .= '<script type="text/javascript" src="' . SimpleSAML\Module::getModuleUrl('mobileid/resources/js/mobileid.js') . '"></script>';
+// $this->data['head'] .= '<link rel="stylesheet" href="' . SimpleSAML\Module::getModuleUrl('mobileid/resources/css/mobileid.css') . '"/>';
 $this->data['header'] = $this->t('{mobileid:Auth:header}');
 $this->data['autofocus'] = 'msisdn';
 $this->includeAtTemplateBase('includes/header.php');
 
 $this->data['cancel'] = '';
-//if (isset($_SESSION['enable_cancel']) && $_SESSION['enable_cancel']) {
-//    $this->data['cancel'] = '<input type="button" value="' . $this->t('{mobileid:Auth:form_btn_cancel}') . '" class="btn float-l mobileid-btn-cancel" id="submit_btn_cancel" />';
-//}
+if (isset($_SESSION['enable_cancel']) && $_SESSION['enable_cancel']) {
+    $this->data['cancel'] = '<input type="button" value="' . $this->t('{mobileid:Auth:form_btn_cancel}') . '" class="btn float-l mobileid-btn-cancel" id="submit_btn_cancel" />';
+}
 
 if ($this->data['errorcode'] !== NULL && array_key_exists('msisdn', $_REQUEST)) {
 	$_COOKIE["msisdn"] = $_REQUEST['msisdn'];
 }
+
+/* Error description */
+$errorDescr = $this->t('{mobileid:errors:descr_' . $this->data['errorcode'] . '}');
+if (array_key_exists('errorurl', $this->data))
+	$errorDescr = str_replace('#URL#', $this->data['errorurl'], $errorDescr);
+if (array_key_exists('mcc', $this->data))
+	$errorDescr = str_replace('#MCC#', $this->data['mcc'], $errorDescr);
+if (array_key_exists('mnc', $this->data))
+	$errorDescr = str_replace('#MNC#', $this->data['mnc'], $errorDescr);
 ?>
 <div style="display:none;" class="alert alert-danger" id="msg_error" role="alert">
 	<span class="glyphicon glyphicon-exclamation-sign" style="font-size: 28px;" aria-hidden="true"></span>
@@ -45,7 +56,7 @@ if ($this->data['errorcode'] !== NULL && array_key_exists('msisdn', $_REQUEST)) 
         ?>
 	<input type="submit" value="<?php echo $this->t('{mobileid:Auth:form_btn_send}'); ?>" class="btn btn-default btn-primary mobileid-btn-send col-lg-3" id="submit_btn_send" />
 
-	<img style="height:28px; float:right;" src="<?php echo(SimpleSAML_Module::getModuleURL('mobileid/resources/mobileid.png')); ?>" />
+	<img style="height:28px; float:right;" src="<?php echo(SimpleSAML\Module::getModuleURL('mobileid/resources/mobileid.png')); ?>" />
 	<?php
 	foreach ($this->data['stateparams'] as $name => $value) {
 		echo('<input type="hidden" name="' . htmlspecialchars($name) . '" value="' . htmlspecialchars($value) . '" />');
@@ -54,7 +65,7 @@ if ($this->data['errorcode'] !== NULL && array_key_exists('msisdn', $_REQUEST)) 
 </form>
 </div>
 <div id="msg_wait" style="display:none;" class="row-fluid">
-	<img class="mobileid-ajax-loader" src="<?php echo(SimpleSAML_Module::getModuleURL('abacustheme/pics/ajax-loader.gif')); ?>" alt="<?php echo $this->t('{mobileid:Auth:msg_wait}'); ?>" title="<?php echo $this->t('{mobileid:Auth:msg_wait}'); ?>" />
+	<img class="mobileid-ajax-loader" src="<?php echo(SimpleSAML\Module::getModuleURL('abacustheme/pics/ajax-loader.gif')); ?>" alt="<?php echo $this->t('{mobileid:Auth:msg_wait}'); ?>" title="<?php echo $this->t('{mobileid:Auth:msg_wait}'); ?>" />
 	<p><?php echo $this->t('{mobileid:Auth:msg_wait}'); ?></p>
 </div>
 <?php if ($this->data['errorcode'] !== NULL) { ?>

--- a/themes/abacustheme/default/includes/header.php
+++ b/themes/abacustheme/default/includes/header.php
@@ -24,7 +24,7 @@ if (array_key_exists('pageid', $this->data)) {
 		'page' => $this->data['pageid']
 	);
 		
-	SimpleSAML_Module::callHooks('htmlinject', $hookinfo);	
+	SimpleSAML\Module::callHooks('htmlinject', $hookinfo);	
 }
 // - o - o - o - o - o - o - o - o - o - o - o - o -
 
@@ -53,11 +53,11 @@ if(array_key_exists('header', $this->data)) {
 }
 ?></title>
 
-	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/css/abacus.css'); ?>" />
-	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/css/default.css'); ?>" />
-	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/css/bootstrap.min.css'); ?>" />
-	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/css/bootstrap-responsive.min.css'); ?>" />
-	<link rel="icon" type="image/icon" href="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/pics/favicon.ico'); ?>" />
+	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/abacus.css'); ?>" />
+	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/default.css'); ?>" />
+	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/bootstrap.min.css'); ?>" />
+	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/bootstrap-responsive.min.css'); ?>" />
+	<link rel="icon" type="image/icon" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/pics/favicon.ico'); ?>" />
 
 <?php
 
@@ -85,7 +85,7 @@ if(!empty($jquery)) {
 			echo('<script type="text/javascript" src="/' . $this->data['baseurlpath'] . 'resources/jquery-ui-16.js"></script>' . "\n");
 	
 		if (isset($jquery['css']) && $jquery['css'])
-			echo('<link rel="stylesheet" media="screen" type="text/css" href="' . SimpleSAML_Module::getModuleURL('abacustheme/uitheme16/ui.all.css') . '"/>' . "\n");	
+			echo('<link rel="stylesheet" media="screen" type="text/css" href="' . SimpleSAML\Module::getModuleURL('abacustheme/uitheme16/ui.all.css') . '"/>' . "\n");	
 	}
 }
 
@@ -114,7 +114,7 @@ if(array_key_exists('head', $this->data)) {
 	echo '<!-- head -->' . $this->data['head'] . '<!-- /head -->';
 }
 ?>
-<script type="text/javascript" src="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/js/bootstrap.min.js'); ?>"></script>
+<script type="text/javascript" src="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/js/bootstrap.min.js'); ?>"></script>
 </head>
 <?php
 $onLoad = '';
@@ -134,7 +134,7 @@ if($onLoad !== '') {
 <div id="main-wrapper">
 	<div id="main">
 		<div id="logo-meta-section">
-			<div id="logo"><img src="<?php echo SimpleSAML_Module::getModuleURL('abacustheme/pics/abacus_logo.gif'); ?>" class="logo" alt="Home" /></div>
+			<div id="logo"><img src="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/pics/abacus_logo.gif'); ?>" class="logo" alt="Home" /></div>
 			<div id="metanavigation">
                             <?php 
 	

--- a/themes/abacustheme/default/includes/header.php
+++ b/themes/abacustheme/default/includes/header.php
@@ -56,7 +56,6 @@ if(array_key_exists('header', $this->data)) {
 	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/abacus.css'); ?>" />
 	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/default.css'); ?>" />
 	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/bootstrap.min.css'); ?>" />
-	<link rel="stylesheet" type="text/css" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/css/bootstrap-responsive.min.css'); ?>" />
 	<link rel="icon" type="image/icon" href="<?php echo SimpleSAML\Module::getModuleURL('abacustheme/pics/favicon.ico'); ?>" />
 
 <?php

--- a/themes/abacustheme/mobileid/mobileidtemplate.php
+++ b/themes/abacustheme/mobileid/mobileidtemplate.php
@@ -2,70 +2,82 @@
 /**
  * This is the associated template page for the Mobile ID login form
  *
- * @version     1.0.0
+ * @version     1.0.2
  * @package     simpleSAMLphp-mobileid
  * @copyright   Copyright (C) 2012. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.md
- * @author      Swisscom (Schweiz AG)
+ * @author      Swisscom (Schweiz) AG
  */
 
-$this->data['head']  = '<script type="text/javascript" src="' . SimpleSAML_Module::getModuleUrl('mobileid/resources/js/jquery/jquery-1.8.3.min.js') . '"></script>';
-$this->data['head'] .= '<script type="text/javascript" src="' . SimpleSAML_Module::getModuleUrl('mobileid/resources/js/mobileid.js') . '"></script>';
+$this->data['head']  = '<script type="text/javascript" src="' . SimpleSAML\Module::getModuleUrl('mobileid/resources/js/jquery/jquery-1.8.3.min.js') . '"></script>';
+$this->data['head'] .= '<script type="text/javascript" src="' . SimpleSAML\Module::getModuleUrl('mobileid/resources/js/mobileid.js') . '"></script>';
+$this->data['head'] .= '<link rel="stylesheet" href="' . SimpleSAML\Module::getModuleUrl('mobileid/resources/css/mobileid.css') . '"/>';
 $this->data['header'] = $this->t('{mobileid:Auth:header}');
 $this->data['autofocus'] = 'msisdn';
 $this->includeAtTemplateBase('includes/header.php');
 
-if ($this->data['errorcode'] !== NULL && array_key_exists('msisdn', $_REQUEST)) {
-	$_COOKIE["msisdn"] = $_REQUEST['msisdn'];
+$this->data['cancel'] = '';
+if (isset($_SESSION['enable_cancel']) && $_SESSION['enable_cancel']) {
+    $this->data['cancel'] = '<input type="button" value="' . $this->t('{mobileid:Auth:form_btn_cancel}') . '" class="float-l mobileid-btn-cancel" id="submit_btn_cancel" />';
 }
+
+if ($this->data['errorcode'] !== NULL && array_key_exists('msisdn', $_REQUEST)) {
+    $_COOKIE["msisdn"] = $_REQUEST['msisdn'];
+}
+
+/* Error description */
+$errorDescr = $this->t('{mobileid:errors:descr_' . $this->data['errorcode'] . '}');
+if (array_key_exists('errorurl', $this->data))
+    $errorDescr = str_replace('#URL#', $this->data['errorurl'], $errorDescr);
+if (array_key_exists('mcc', $this->data))
+    $errorDescr = str_replace('#MCC#', $this->data['mcc'], $errorDescr);
+if (array_key_exists('mnc', $this->data))
+    $errorDescr = str_replace('#MNC#', $this->data['mnc'], $errorDescr);
 ?>
-
-<img style="height:100px; display:inline;padding:0px;margin:0 20px 0 0; float:right;" src="<?php echo(SimpleSAML_Module::getModuleURL('abacustheme/pics/swisscom.gif')); ?>" />
-
-<div class="mobileid-main">
-<h2 style=""><?php echo $this->t('{mobileid:Auth:header}'); ?></h2>
-<div id="msg_error" class="alert alert-block alert-error" style="display:none">
-        <button type="button" class="close" data-dismiss="alert">×</button>
-	<strong><?php echo $this->t('{mobileid:errors:error_header}'); ?></strong>
-	<p><?php echo $this->t('{mobileid:errors:descr_' . $this->data['errorcode'] . '}'); ?></p>
+<style type="text/css">
+	#msg_wait{display:none;}
+</style>
+<div style="border-left: 1px solid #e8e8e8; border-bottom: 1px solid #e8e8e8; background: #f5f5f5; display:none;" id="msg_error">
+    <img src="/<?php echo $this->data['baseurlpath']; ?>resources/icons/experience/gtk-dialog-error.48x48.png" class="float-l" style="margin: 15px " />
+    <h2><?php echo $this->t('{mobileid:errors:error_header}'); ?></h2>
+    <p><?php echo $errorDescr; ?></p>
 </div>
-
-
-
+<h2 style=""><?php echo $this->t('{mobileid:Auth:header}'); ?>
+    <img style="height:28px; float:right;" src="<?php echo(SimpleSAML\Module::getModuleURL('mobileid/resources/mobileid.png')); ?>" />
+</h2>
 <form action="?" method="post" name="f" id="mobileid_form">
-	
-              <div class="control-group">
-                  <h4><?php echo $this->t('{mobileid:Auth:intro}'); ?></h4>
-			<div class="mobileid-controls">
-				
-				<input id="msisdn" size="30" name="msisdn" tabindex="1" class="msisdn mobileid-input" type="tel" value="<?php if (isset($_COOKIE["msisdn"])) echo $_COOKIE["msisdn"]; ?>" />        
-			</div>
-                        <div class="form-actions">
-                             <input type="button" value="<?php echo $this->t('{mobileid:Auth:form_btn_send}'); ?>" class="float-r mobileid-btn-send" id="submit_btn_send" />
-                             <input type="button" value="<?php echo $this->t('{mobileid:Auth:form_btn_cancel}'); ?>" class="float-l mobileid-btn-cancel" id="submit_btn_cancel" />
-
-                      </div>
-               </div>
-                                
-                 
-                                        
-
-	<?php
-	foreach ($this->data['stateparams'] as $name => $value) {
-		echo('<input type="hidden" name="' . htmlspecialchars($name) . '" value="' . htmlspecialchars($value) . '" />');
-	}
-	?>
+    <table>
+        <tbody>
+            <tr width="100%">
+                <td style="padding: .3em;"><?php echo $this->t('{mobileid:Auth:intro}'); ?></td>
+                <td><input id="msisdn" size="30" name="msisdn" tabindex="1" class="msisdn mobileid-input" type="tel" value="<?php if (isset($_COOKIE["msisdn"])) echo $_COOKIE["msisdn"]; ?>" /></td>
+            </tr>
+            <tr>
+                <td>&nbsp;</td>
+                <td>
+                    <?php
+                    if ($this->data['cancel'] !== '')
+                        echo($this->data['cancel']);
+                    ?>
+                    <input type="button" value="<?php echo $this->t('{mobileid:Auth:form_btn_send}'); ?>" class="float-r mobileid-btn-send" id="submit_btn_send" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <?php
+    foreach ($this->data['stateparams'] as $name => $value) {
+        echo('<input type="hidden" name="' . htmlspecialchars($name) . '" value="' . htmlspecialchars($value) . '" />');
+    }
+    ?>
 </form>
-<br/>
-<div id="msg_wait" style="display:none;">
-	<img class="mobileid-ajax-loader" src="<?php echo(SimpleSAML_Module::getModuleURL('abacustheme/pics/ajax-loader.gif')); ?>" alt="<?php echo $this->t('{mobileid:Auth:msg_wait}'); ?>" title="<?php echo $this->t('{mobileid:Auth:msg_wait}'); ?>" />
-	<p><?php echo $this->t('{mobileid:Auth:msg_wait}'); ?></p>
-</div>
+<div id="msg_wait">
+    <div id="spinner"></div>
+    <p><?php echo $this->t('{mobileid:Auth:msg_wait}'); ?></p>
 </div>
 <?php if ($this->data['errorcode'] !== NULL) { ?>
 <script>
-	jQuery('#msg_wait').hide();
-	jQuery('#msg_error').show();
+    jQuery('#msg_wait').hide();
+    jQuery('#msg_error').show();
 </script>
 <?php } ?>
 <?php $this->includeAtTemplateBase('includes/footer.php'); ?>


### PR DESCRIPTION
Bitte rewiew. Wieso hat es 2 template folders?

Und beim Admin Login gibt es noch diese Fehlermeldungen:
Jul 01 10:04:07 simplesamlphp ERROR [eb398efd83] /simplesamlphp/module.php/core/loginuserpass.php - Template: Could not find dictionary file at [/usr/share/simplesamlphp/modules/selfregister/dictionaries/selfregister]
Jul 01 10:04:07 simplesamlphp INFO [eb398efd83] Template: Looking up [{selfregister:selfregister:link_lostpw}]: not translated at all.
Jul 01 10:04:07 simplesamlphp INFO [eb398efd83] Template: Looking up [{selfregister:selfregister:link_newuser}]: not translated at all.
Jul 01 10:04:07 simplesamlphp ERROR [eb398efd83] SimpleSAML_Error_NotFound: The requested page 'http://abacore01/simplesamlphp/module.php/selfregister/api.php' could not be found. The module 'selfregister' was either not found, or wasn't enabled.
Jul 01 10:04:07 simplesamlphp ERROR [eb398efd83] Backtrace:
Jul 01 10:04:07 simplesamlphp ERROR [eb398efd83] 0 /usr/share/simplesamlphp/www/module.php:66 (N/A)
Jul 01 10:04:07 simplesamlphp ERROR [eb398efd83] Error report with id 749c9115 generated.